### PR TITLE
Modified existing macros and added two more

### DIFF
--- a/Macros/Create_Coil_Combinations.mcr
+++ b/Macros/Create_Coil_Combinations.mcr
@@ -18,7 +18,7 @@ Sub Main ()
 
 	'########################################INSERT PARAMETERS HERE#################################################'
 	nb_coils = 8
-	port_start = 24
+	port_start = 1
 	Extra_Tasks = Array("CPmode", "negCPMode", "zeroPhase")
 
 	'Default value for magnitude and phase. Used to simulate on the phantom'
@@ -27,7 +27,7 @@ Sub Main ()
 	'###########################################################################################################'
 
 	With SimulationTask
-		.name("Coil_Combinations")
+		.name("CoilCombinations")
 		.type("sequence")
 		.SetProperty ("enabled", "False")
 		.create
@@ -35,21 +35,26 @@ Sub Main ()
 
 	For i = 1 To nb_coils
 		With SimulationTask
-			.name("Coil_Combinations\Coil_" & i)
+			.name("CoilCombinations\Coil_" & i)
 			.type("ac")
 			.create
 
 			.SetProperty ("maximum frequency range", "True")
+			.SetProperty ("blocknameforcombineresults", "MWSSCHEM1")
+			.SetProperty ("docombineresults", "True")
+			.ResetCombineMonitorFilters
+			.AddCombineMonitorFilter(":hfield:")
 			.SetProperty ("enabled", "False")
 			.EnableResult ("block", True )
 			.SetComplexPortExcitation(port_start - 1 + i, phantom_magnitude, phantom_phase)
 			.SetPortSourceType (port_start - 1 + i, "signal")
+
 		End With
 	Next i
 
 	For Each task In Extra_Tasks
 		With SimulationTask
-			.name("Coil_Combinations\" & task)
+			.name("CoilCombinations\" & task)
 			.type("ac")
 			.create
 

--- a/Macros/Create_SAR_Excitations.mcr
+++ b/Macros/Create_SAR_Excitations.mcr
@@ -17,7 +17,7 @@ Sub Main ()
 
 	'########################################INSERT PARAMETERS HERE#################################################'
 	nb_coils = 8
-	port_start = 24
+	port_start = 1
 	default_phase = 0
 	default_magnitude = 1
 	'###########################################################################################################'
@@ -39,6 +39,10 @@ Sub Main ()
 
 				.SetProperty ("maximum frequency range", "True")
 				.SetProperty ("enabled", "True")
+				.SetProperty ("blocknameforcombineresults", "MWSSCHEM1")
+				.SetProperty ("docombineresults", "True")
+				.ResetCombineMonitorFilters
+				.AddCombineMonitorFilter(":powerloss:")
 				.EnableResult ("block", True )
 				.SetComplexPortExcitation(port_start - 1 + i, default_magnitude, default_phase)
 				.SetComplexPortExcitation(port_start - 1 + j, default_magnitude, default_phase)
@@ -54,6 +58,10 @@ Sub Main ()
 
 					.SetProperty ("maximum frequency range", "True")
 					.SetProperty ("enabled", "True")
+					.SetProperty ("blocknameforcombineresults", "MWSSCHEM1")
+					.SetProperty ("docombineresults", "True")
+					.ResetCombineMonitorFilters
+					.AddCombineMonitorFilter(":powerloss:")
 					.EnableResult ("block", True )
 					.SetComplexPortExcitation(port_start - 1 + i, default_magnitude, default_phase)
 					.SetComplexPortExcitation(port_start - 1 + j, default_magnitude, default_phase)

--- a/Macros/Postprocessing_CalculateSAR.mcr
+++ b/Macros/Postprocessing_CalculateSAR.mcr
@@ -1,0 +1,62 @@
+' Postprocessing_CalculateSAR
+' This Macro calculates SAR for all your SAR_excitations.
+' You can also add extra tasks like CP mode with the Extra_Tasks parameters
+
+'Custom parameters
+'nb_coils: Number of coils
+'Extra_Tasks: Extra tasks other than coils you want to add
+
+Sub Main ()
+	Dim nb_coils As Integer
+
+
+	'####################INSERT PARAMETERS HERE###########################'
+	nb_coils = 1
+	Extra_Tasks = Array("CPmode", "negCPMode", "zeroPhase")
+
+	'#####################################################################'
+
+
+	For i = 1 To nb_coils
+		For j = i To nb_coils
+			With SAR
+				.Reset
+				.PowerlossMonitor ("loss (f=297.2) [SAR_excitations@Exc_" & i & "_" & j & "]")
+				.AverageWeight (10)
+				.SetOption ("no subvolume")
+				.SetOption ("rescale 1")
+				.SetOption ("scale stimulated")
+				.SetOption ("CST C95.3")
+				.Create
+			End With
+
+		If i <> j Then
+			With SAR
+				.Reset
+				.PowerlossMonitor ("loss (f=297.2) [SAR_excitations@Exc_" & i & "_" & j & "_prime]")
+				.AverageWeight (10)
+				.SetOption ("no subvolume")
+				.SetOption ("rescale 1")
+				.SetOption ("scale stimulated")
+				.SetOption ("CST C95.3")
+				.Create
+				End With
+		End If
+		Next j
+	Next i
+
+	For Each task In Extra_Tasks
+		With SAR
+				.Reset
+				.PowerlossMonitor ("loss (f=297.2) [CoilCombinations@" & task & "]")
+				.AverageWeight (10)
+				.SetOption ("no subvolume")
+				.SetOption ("rescale 1")
+				.SetOption ("scale stimulated")
+				.SetOption ("CST C95.3")
+				.Create
+		End With
+	Next task
+
+End Sub
+

--- a/Macros/Postprocessing_ExportSAR.mcr
+++ b/Macros/Postprocessing_ExportSAR.mcr
@@ -1,0 +1,67 @@
+' Postprocessing_ExportSAR
+' This Macro calculates exports SAR for all your SAR_excitations
+
+'Custom parameters
+'nb_coils: Number of coils
+'xmin, xmax, ymin, ymax, zmin, zmax: subvolume for SAR export
+'stepwidth: step width for data export (in units of project)
+'export_directory: directory for exported SAR files (directory must already exist)
+
+Sub Main ()
+	Dim nb_coils As Integer
+	Dim xmin As Double
+	Dim xmax As Double
+	Dim ymin As Double
+	Dim ymax As Double
+	Dim zmin As Double
+	Dim zmax As Double
+	Dim stepwidth As Double
+	Dim export_directory As String
+
+
+	'####################INSERT PARAMETERS HERE###########################'
+	nb_coils = 1
+
+	xmin = -9.5
+	xmax = 9.5
+	ymin = -4.5
+	ymax = 6.5
+	zmin = -11.5
+	zmax = 4
+
+	stepwidth = 0.1
+
+	export_directory = "E:\20220906_VisualCoil_Gustav_mask"
+
+	'#####################################################################'
+
+	For i = 1 To nb_coils
+		For j = i To nb_coils
+		SelectTreeItem ("2D/3D Results\SAR\SAR (f=297.2) [SAR_excitations@Exc_" & i & "_" & j & "] (10g)")
+			With ASCIIExport
+    			.Reset
+    			.FileName (export_directory & "\SAR (f=297.2) [SAR_excitations@Exc_" & i & "_" & j & "] (10g).txt")
+    			.Mode("FixedWidth")
+    			.Step (stepwidth)
+    			.SetSubvolume(xmin, xmax, ymin, ymax, zmin, zmax)
+    			.UseSubvolume("True")
+   				.Execute
+			End With
+
+		If i <> j Then
+				SelectTreeItem ("2D/3D Results\SAR\SAR (f=297.2) [SAR_excitations@Exc_" & i & "_" & j & "_prime] (10g)")
+			With ASCIIExport
+    			.Reset
+    			.FileName (export_directory & "\SAR (f=297.2) [SAR_excitations@Exc_" & i & "_" & j & "_prime] (10g).txt")
+    			.Mode("FixedWidth")
+    			.Step (stepwidth)
+    			.SetSubvolume(xmin, xmax, ymin, ymax, zmin, zmax)
+   				.Execute
+   			End With
+
+		End If
+		Next j
+	Next i
+
+End Sub
+

--- a/Macros/Set_tasks_magnitude_and_phase.mcr
+++ b/Macros/Set_tasks_magnitude_and_phase.mcr
@@ -11,21 +11,23 @@
 Sub Main ()
 	Dim Magnitudes As Variant
 	Dim Phases As Variant
+	Dim CPmodePhases As Variant
 	Dim nb_coils As Integer
 	Dim Port_offset As Integer
 
 	'########################################INSERT PARAMETERS HERE#################################################'
 	nb_coils = 8
-	port_start = 24
-	Magnitudes = Array(1, 2, 3, 4, 5, 6, 7, 8)
-	Phases = Array(10, -20, 30, -40, 50, -60, 70, -80)
+	port_start = 1
+	Magnitudes = Array(0.971, 0.753, 0.836, 1.024, 1.315, 0.682, 0.904, 1.098)
+	Phases = Array(-67, -55, 16, 130, 262, -83, 42, 155)
+	CPmodePhases = Array(0, 93, -123, 110, 147, 61, -78, 202)
 	Extra_Tasks = Array("CPmode", "negCPMode", "zeroPhase")
 	'###########################################################################################################'
 
 	'#########Loop through every coil######'
 	For Coil = 1 To nb_coils
 		With SimulationTask
-			.name("Coil_Combinations\Coil_" & Coil)
+			.name("CoilCombinations\Coil_" & Coil)
 			.SetComplexPortExcitation(port_start - 1 + Coil, Magnitudes(Coil-1), Phases(Coil-1))
 		End With
 			For Coil2 = Coil To nb_coils
@@ -58,9 +60,9 @@ Sub Main ()
 		End If
 
 		With SimulationTask
-			.name("Coil_Combinations\" & task)
+			.name("CoilCombinations\" & task)
 			For Port = port_start To port_start + nb_coils -1
-				.SetComplexPortExcitation(Port, Magnitudes(Port - port_start), phase_sign * Phases(Port - port_start))
+				.SetComplexPortExcitation(Port, Magnitudes(Port - port_start), Phases(Port - port_start) - (phase_sign * CPmodePhases(Port - port_start)) )
 			Next Port
 		End With
 	Next task

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ If you would like to develop your own macro to script task parameters in CST, I 
 **Disclaimer**: These macros are meant to be used together. If you only want to use one in particular, make sure the nomenclature of your tasks respects the norms used in these macros. 
 
 ### Norms:
-1. All coil tasks are in a sequence called Coil_Combinations
+1. All coil tasks are in a sequence called CoilCombinations
 2. All coil tasks are named Coil_#, where # is the coil number
 3. All excitation tasks are regrouped in a sequence called SAR_Excitations
 4. All excitations tasks are named Exc_#1_#2 or Exc_#1_#2_prime, where #1 is the first coil number and #2 the second coil number
-5. All extra tasks must be included in the Coil_Combinations sequence
+5. All extra tasks must be included in the CoilCombinations sequence
 6. Extra tasks must contain the word zero if you want your phases to be zero for this task and neg if you want the opposite sign for your phases. If none of these keywords are present, the phases will be set to their normal value.
+7. The block name of your schematic must be called MWSSCHEM1 (this is the default block name)
 
 ### How to add a macro:
 1. Download the zip file from this repository


### PR DESCRIPTION
I modified the existing macros to fix some issues as detailed below, and added two additional macros for calculating and exporting SAR. I have yet to figure out how to calculate the B1 plus field through a VBA macro, but will keep looking into it.

Changes to existing macros:
1. `Create_Coil_Combinations.mcr`:
* Changed the name (removed the space) to make it backwards compatible with exiting VOP code
* Added the field-monitor combination of the h-field for individual coils; Extra Tasks combine all field monitors
* Requires the default block name of `MWSSCHEM1`, which is the default name assigned to the first block simulation

2. `Create_SAR_Excitations.mcr`:
* Added the field-monitor combination of the power-loss monitor for each SAR excitation

3. `Set_tasks_magnitude_and_phase.mcr`:
* Corrected the computation of the phase for all Extra Tasks

4. `Postprocessing_CalculateSAR.mcr`:
* This new macro will calculate the SAR for each SAR excitation and Extra Tasks
* Calculates the 10-g averaged SAR and normalizes to 1-W stimulated power, as required by the VOP code
* Uses the C95.3 averaging scheme to calculate SAR, as recommended by CST

5. `Postprocessing_ExportSAR.mcr`:
* Exports SAR from SAR excitations and Extra Tasks
* Exports over user-defined sub-volume and step width
* The user must specify the output directory for exported files -- this directory must already exist or there will be an error

6. `README`:
* modified to reflect the default name of `CoilCombinations` and to include the required block name
